### PR TITLE
Fixed Interactions between Molar and LGU upgrades

### DIFF
--- a/LGUCompatibility.cs
+++ b/LGUCompatibility.cs
@@ -1,7 +1,11 @@
-﻿using System;
+﻿using HarmonyLib;
+using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.UI.TerminalNodes;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Unity.Netcode;
 using static MilkMolars.Plugin;
 
 namespace MilkMolars
@@ -41,7 +45,8 @@ namespace MilkMolars
                     upgrade.name = node.OriginalName;
                     upgrade.title = node.Name;
                     upgrade.LGUUpgrade = true;
-                    
+                    upgrade.unlocked = node.Unlocked;
+
                     if (node.Prices.Length > 0)
                     {
                         upgrade.type = MilkMolarUpgrade.UpgradeType.LGUTier;
@@ -55,19 +60,20 @@ namespace MilkMolars
                             costsPerTierList.Add((int)Math.Ceiling(price / configLGUMilkMolarContributeAmount.Value));
                         }
 
-                        if (node.CurrentUpgrade == 0)
-                        {
-                            if (node.Unlocked) { upgrade.currentTier = 1; }
-                            else { upgrade.currentTier = 0; }
-                        }
-                        else
-                        {
-                            upgrade.currentTier = node.CurrentUpgrade + 1;
-                            upgrade.unlocked = true;
-                        }
-
                         upgrade.costsPerTier = costsPerTierList.ToArray();
                         logger.LogDebug("Upgrade costs: " + string.Join(", ", upgrade.costsPerTier));
+
+                        if (!upgrade.unlocked)
+                            upgrade.currentTier = 0;
+                        else upgrade.currentTier = node.CurrentUpgrade + 1;
+
+                        logger.LogDebug($"Upgrade unlocked and tier: {upgrade.unlocked}, {upgrade.currentTier}");
+
+                        if (upgrade.currentTier >= upgrade.maxTier)
+                        {
+                            upgrade.fullyUpgraded = true;
+                        }
+                        logger.LogDebug($"Upgrade fully upgrade: {upgrade.fullyUpgraded}");
                     }
                     else
                     {
@@ -91,6 +97,7 @@ namespace MilkMolars
                     upgrade.name = node.OriginalName;
                     upgrade.title = node.Name;
                     upgrade.LGUUpgrade = true;
+                    upgrade.unlocked = node.Unlocked;
 
                     if (node.Prices.Length > 0)
                     {
@@ -105,15 +112,20 @@ namespace MilkMolars
                             costsPerTierList.Add((int)Math.Ceiling(price / configLGUMegaMilkMolarContributeAmount.Value));
                         }
 
-                        if (node.CurrentUpgrade == 0)
-                        {
-                            if (node.Unlocked) { upgrade.currentTier = 1; }
-                            else { upgrade.currentTier = 0; }
-                        }
-                        else { upgrade.currentTier = node.CurrentUpgrade + 1; }
-
                         upgrade.costsPerTier = costsPerTierList.ToArray();
                         logger.LogDebug("Upgrade costs: " + string.Join(", ", upgrade.costsPerTier));
+
+                        if (!upgrade.unlocked)
+                            upgrade.currentTier = 0;
+                        else upgrade.currentTier = node.CurrentUpgrade + 1;
+
+                        logger.LogDebug($"Upgrade unlocked and tier: {upgrade.unlocked}, {upgrade.currentTier}");
+
+                        if (upgrade.currentTier >= upgrade.maxTier)
+                        {
+                            upgrade.fullyUpgraded = true;
+                        }
+                        logger.LogDebug($"Upgrade fully upgrade: {upgrade.fullyUpgraded}");
                     }
                     else
                     {
@@ -160,6 +172,40 @@ namespace MilkMolars
             if (node != null && !node.Unlocked)
             {
                 MoreShipUpgrades.Managers.LguStore.Instance.HandleUpgrade(node);
+            }
+        }
+    }
+    [HarmonyPatch]
+    internal static class LguStorePatcher
+    {
+        [HarmonyPatch(typeof(LguStore), nameof(LguStore.UpdateUpgrades))]
+        [HarmonyPostfix]
+        static void UpdateUpgradesPostfix(CustomTerminalNode node)
+        {
+            MilkMolarUpgrade molarUpgrade;
+            if (node.SharedUpgrade)
+            {
+                molarUpgrade = NetworkHandler.MegaMilkMolarUpgrades.Where(x => x.LGUUpgrade && x.name == node.OriginalName).FirstOrDefault();
+            }
+            else
+            {
+                molarUpgrade = MilkMolarController.MilkMolarUpgrades.Where(x => x.LGUUpgrade && x.name == node.OriginalName).FirstOrDefault();
+            }
+            if (molarUpgrade == null) return; // Wasn't found an upgrade for the LGU one
+            molarUpgrade.GoToNextTier();
+        }
+        [HarmonyPatch(typeof(LguStore), nameof(LguStore.WaitForUpgradeObject), MethodType.Enumerator)]
+        [HarmonyPostfix]
+        static void WaitForUpgradeObjectPostfix(bool __result)
+        {
+            if (__result) return;
+            Plugin.LoggerInstance.LogDebug("YIPPPPPPPPPPPPPPPPPIE");
+            NetworkHandler.MegaMilkMolarUpgrades.AddRange(LGUCompatibility.GetLGUUpgrades(mega: true));
+            MilkMolarController.MilkMolarUpgrades.AddRange(LGUCompatibility.GetLGUUpgrades());
+
+            if (!(NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsServer))
+            {
+                MilkMolarController.GetMegaMilkMolarUpgrades();
             }
         }
     }

--- a/MilkMolarController.cs
+++ b/MilkMolarController.cs
@@ -78,12 +78,6 @@ namespace MilkMolars
                 // Carry weight
                 //upgrades.Add(new MilkMolarUpgrade("CarryWeight", "Carry Weight", MilkMolarUpgrade.UpgradeType.TierPercent, configCarryWeightUpgrade.Value));
             }
-            else
-            {
-                List<MilkMolarUpgrade> lguUpgrades = new List<MilkMolarUpgrade>();
-                lguUpgrades = LGUCompatibility.GetLGUUpgrades();
-                upgrades.AddRange(lguUpgrades);
-            }
 
             // Shovel damage
             //upgrades.Add(new MilkMolarUpgrade("ShovelDamage", "Shovel Damage", MilkMolarUpgrade.UpgradeType.TierNumber, configShovelDamageUpgrade.Value));
@@ -146,13 +140,6 @@ namespace MilkMolars
                     // Company Cruiser max speed
                     // Company Cruiser turning
                     // Company Cruiser damage reduction
-                }
-                else
-                {
-                    logger.LogDebug("Getting lguUpgrades. mega: " + true);
-                    List<MilkMolarUpgrade> lguUpgrades = new List<MilkMolarUpgrade>();
-                    lguUpgrades = LGUCompatibility.GetLGUUpgrades(true);
-                    upgrades.AddRange(lguUpgrades);
                 }
 
                 // Keep items on ship chance

--- a/NetworkHandler.cs
+++ b/NetworkHandler.cs
@@ -191,8 +191,6 @@ namespace MilkMolars
                         }
                     }
                 }
-
-                if (LGUCompatibility.enabled) { NetworkHandler.MegaMilkMolarUpgrades.AddRange(LGUCompatibility.GetLGUUpgrades(mega: true)); }
             }
 
             if (File.Exists(MilkMolarsPath))
@@ -231,8 +229,6 @@ namespace MilkMolars
                     }
                 }
             }
-
-            if (LGUCompatibility.enabled) { MilkMolarController.MilkMolarUpgrades.AddRange(LGUCompatibility.GetLGUUpgrades()); }
 
             if (!(NetworkManager.Singleton.IsHost || NetworkManager.Singleton.IsServer))
             {

--- a/Patches/StartOfRoundPatch.cs
+++ b/Patches/StartOfRoundPatch.cs
@@ -1,15 +1,5 @@
 ﻿using BepInEx.Logging;
 using HarmonyLib;
-using InteractiveTerminalAPI.UI;
-using LethalLib.Extras;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Unity.Netcode;
-using UnityEngine;
-using static MilkMolars.Plugin;
-using Newtonsoft.Json;
 
 namespace MilkMolars
 {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -109,7 +109,13 @@ namespace MilkMolars
             LoggerInstance = PluginInstance.Logger;
             LoggerInstance.LogDebug("Loaded logger for MilkMolarsMod");
 
-            harmony.PatchAll();
+            harmony.PatchAll(typeof(DeleteFileButtonPatch));
+            harmony.PatchAll(typeof(DepositItemsDeskPatch));
+            harmony.PatchAll(typeof(PlayerControllerBPatch));
+            harmony.PatchAll(typeof(RoundManagerPatch));
+            harmony.PatchAll(typeof(StartOfRoundPatch));
+            harmony.PatchAll(typeof(TerminalPatch));
+            harmony.PatchAll(typeof(NetworkObjectManager));
             LoggerInstance.LogDebug("Patched MilkMolarsMod");
 
             InitializeNetworkBehaviours();
@@ -177,6 +183,7 @@ namespace MilkMolars
             // add more days to quota
             LoggerInstance.LogDebug("Got configs");
 
+            if (LGUCompatibility.enabled) harmony.PatchAll(typeof(LguStorePatcher));
 
             // Loading Assets
             string sAssemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);


### PR DESCRIPTION
- Fixed upgrading a LGU upgrade from its store not updating the respective molar upgrade.
- Fixed molar upgrades not being updated correctly from their LGU counterparts when loading back into the lobby.
- Refactored GetLGUUpgrades